### PR TITLE
Java第8回課題として、全件取得すると文字列を指定して検索するAPI処理の作成

### DIFF
--- a/src/main/java/com/ada/mybatisdemo202312/NameController.java
+++ b/src/main/java/com/ada/mybatisdemo202312/NameController.java
@@ -27,6 +27,6 @@ public class NameController {
         System.out.println(request.getStartsWith());
         System.out.println(request.getEndsWith());
         System.out.println(request.getContains());
-        return nameMapper.findByNameStartingWith(request.getStartsWith(), request.getEndsWith(), request.getContains());
+        return nameMapper.findByName(request.getStartsWith(), request.getEndsWith(), request.getContains());
     }
 }

--- a/src/main/java/com/ada/mybatisdemo202312/NameMapper.java
+++ b/src/main/java/com/ada/mybatisdemo202312/NameMapper.java
@@ -10,9 +10,8 @@ public interface NameMapper {
     @Select("SELECT * FROM names")
     List<Name> findAll();
 
-    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%') AND name LIKE CONCAT('%', #{prefix}) AND name LIKE CONCAT('%', #{prefix}, '%')")
-    List<Name> findByNameStartingWith(String prefix, String suffix, String contains);
-//   @Select("SELECT * FROM names WHERE name LIKE CONCAT('#{prefix}%') AND name LIKE CONCAT('%#{prefix}') AND name " +
-//         "LIKE CONCAT('%#{prefix}%')")
-//   List<Name> findByNameStartingWith(String prefix, String suffix, String contains);
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%') AND name LIKE CONCAT('%', #{suffix}) AND " +
+            "name LIKE CONCAT('%', #{contains}, '%')")
+    List<Name> findByName(String prefix, String suffix, String contains);
+
 }


### PR DESCRIPTION
## 目的
Read処理を実装する
 ①テーブルからレコードを全件取得するAPIと全件取得するAPIを作成する
 ②クエリ文字列を指定して検索するAPIを作成する

### 動作確認
### ①全件取得するAPI 
<img width="1264" alt="スクリーンショット 2024-01-08 21 57 56" src="https://github.com/ADA-ad/mybatis-demo-202312/assets/152973671/65e1db88-3f2e-4db8-99ff-548165b7c497">   
curl --location 'http://localhost:8080/names' 

- 200を返すことを確認 
- レスポンスのボティが全件データ(20件)  
### ②文字列指定するAPI 
<img width="1263" alt="スクリーンショット 2024-01-08 22 03 29" src="https://github.com/ADA-ad/mybatis-demo-202312/assets/152973671/485ebd34-26a2-43c8-93e7-4905f04b1c87">  
curl --location 'http://localhost:8080/find?startsWith=j'  
 
- 200を返すことを確認 
- startsWith=j(前方一致)を検索し、レスポンスのボティが5件ある   

<img width="1279" alt="スクリーンショット 2024-01-08 22 11 34" src="https://github.com/ADA-ad/mybatis-demo-202312/assets/152973671/b07123c0-92a8-4619-91ee-66eaf57554c1">
curl --location 'http://localhost:8080/find?endsWith=y' 

- 200を返すことを確認 
- endsWith=y(後方一致)を検索し、レスポンスのボティが4件ある 

<img width="1270" alt="スクリーンショット 2024-01-08 22 16 34" src="https://github.com/ADA-ad/mybatis-demo-202312/assets/152973671/20b0f7a5-06e9-4144-933d-ddfaaf11d1b4"> 
curl --location 'http://localhost:8080/find?contains=m' 

- 200を返すことを確認 
- contains=m(部分一致)を検索し、レスポンスのボティが6件ある 
 
<img width="1260" alt="スクリーンショット 2024-01-08 22 20 06" src="https://github.com/ADA-ad/mybatis-demo-202312/assets/152973671/0d935876-b2b9-43e1-b7a5-ca76839d9449"> 
curl --location 'http://localhost:8080/find?startsWith=j&endsWith=n&contains=o'  

- 200を返すことを確認 
- 複数条件(前方一致、後方一致と部分一致)を検索し、レスポンスのボティが1件ある 





 